### PR TITLE
use npm ci instead of npm install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         cache-dependency-path: package-lock.json
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Run eslint
       run: npm run eslint


### PR DESCRIPTION
`npm ci` is quicker than `npm install` since it uses the package-lock.json instead of the package.json. That will make npm skip some checks and faster linting